### PR TITLE
Add `xcodeproj` gradle property for KMM plugin.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
+xcodeproj=iOS/Multiplatform Redux Sample/Multiplatform Redux Sample.xcworkspace


### PR DESCRIPTION
KMM plugin for Android Studio adds Apple run configuration:  
https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile

**This configuration runs application on iOS device wutout launching Xcode**

<img width="672" alt="изображение" src="https://user-images.githubusercontent.com/3532155/106363155-e8803700-6337-11eb-9ab1-b7b0c46910e7.png">