### PR TITLE
[fix_header_height] Use header heights from design

### DIFF
--- a/iOS/Multiplatform Redux Sample/Multiplatform Redux Sample/Dashboard/AllDisposalsDataSource.swift
+++ b/iOS/Multiplatform Redux Sample/Multiplatform Redux Sample/Dashboard/AllDisposalsDataSource.swift
@@ -26,9 +26,17 @@ class AllDisposalsDataSource: NSObject, UITableViewDataSource, UITableViewDelega
 
         let headerView = UIView()
         headerView.addSubview(label)
-        label.topAnchor.constraint(equalTo: headerView.topAnchor).isActive = true
+        label.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -kUnit2).isActive = true
         headerView.backgroundColor = .testAppGreenLight
         return headerView
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if section == 0 {
+            return kTableViewHeaderHeight - kUnit1
+        } else {
+            return kTableViewHeaderHeight
+        }
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/iOS/Multiplatform Redux Sample/Multiplatform Redux Sample/General/Constants.swift
+++ b/iOS/Multiplatform Redux Sample/Multiplatform Redux Sample/General/Constants.swift
@@ -12,6 +12,7 @@ let kButtonWidth: CGFloat = 212
 let kButtonCornerRadius: CGFloat = 4
 let kCardCornerRadius: CGFloat = 8
 let kPossibleZipContainerHeight: CGFloat = 183
+let kTableViewHeaderHeight: CGFloat = 56
 
 let kHighlightAlphaValue: CGFloat = 0.5
 

--- a/iOS/Multiplatform Redux Sample/Multiplatform Redux Sample/Main/CalendarViewController.swift
+++ b/iOS/Multiplatform Redux Sample/Multiplatform Redux Sample/Main/CalendarViewController.swift
@@ -39,7 +39,6 @@ class CalendarViewController: PresenterViewController<CalendarView>, CalendarVie
         disposalTableView.register(DisposalCell.self, forCellReuseIdentifier: DisposalCell.reuseIdentifier)
         disposalTableView.separatorStyle = .none
         disposalTableView.separatorInset = .zero
-        disposalTableView.sectionHeaderHeight = kUnit5
         disposalTableView.clipsToBounds = false
     }
 


### PR DESCRIPTION
Note: First header height needs to be smaller than other header heights,
since the top tableview needs a bottom spacing because otherwise the
cell shadow get cut off.

Asana Ticket:
https://app.asana.com/0/1199509904376633/1199661788526334/f